### PR TITLE
Remove more dead code.

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,11 +37,6 @@ type JobStatusUpdate struct {
 	UUID string `json:"uuid"`
 }
 
-// DBJobStatusUpdate represents a row from the job_status_updates table
-type DBJobStatusUpdate struct {
-	ExternalID string
-}
-
 // Unpropagated returns a []string of the UUIDs for jobs that have steps that
 // haven't been propagated yet but haven't passed their retry limit.
 func Unpropagated(d *sql.DB, maxRetries int64) ([]string, error) {

--- a/main.go
+++ b/main.go
@@ -152,22 +152,6 @@ func (p *Propagator) JobUpdates(extID string, maxRetries int64) ([]DBJobStatusUp
 	return retval, err
 }
 
-// MarkPropagated marks the job as propagated in the database as part of the
-// transaction tracked by the *Propagator.
-func (p *Propagator) MarkPropagated(id string) error {
-	tx, err := p.db.Begin()
-	if err != nil {
-		return err
-	}
-	updateStr := `UPDATE ONLY job_status_updates SET propagated = 'true' where id = $1`
-	if _, err = tx.Exec(updateStr, id); err != nil {
-		tx.Rollback()
-		return err
-	}
-	tx.Commit()
-	return nil
-}
-
 // ScanAndPropagate marks any unpropagated updates that appear __before__ a
 // propagated update as propagated.
 func (p *Propagator) ScanAndPropagate(updates []DBJobStatusUpdate, maxRetries int64) error {

--- a/main_test.go
+++ b/main_test.go
@@ -100,10 +100,6 @@ func TestPropagate(t *testing.T) {
 		t.Errorf("unfulfilled expectations from NewPropagator()")
 	}
 
-	status := &DBJobStatusUpdate{
-		ExternalID: "external-id",
-	}
-
 	err = p.Propagate("external-id")
 	if err != nil {
 		t.Errorf("error from Propagate(): %s", err)
@@ -114,7 +110,7 @@ func TestPropagate(t *testing.T) {
 		t.Errorf("error unmarshalling body: %s", err)
 	}
 
-	if actual.UUID != status.ExternalID {
-		t.Errorf("uuid field was %s instead of %s", actual.UUID, status.ExternalID)
+	if actual.UUID != "external-id" {
+		t.Errorf("uuid field was %s instead of %s", actual.UUID, "external-id")
 	}
 }


### PR DESCRIPTION
Removes support for pinging the service over AMQP. We never use it and the intended use case is better served by kubernetes.

I also removed what appeared to be a redundant query that was getting run for each job and just chewed up time.